### PR TITLE
docs: Add link to play the game online in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Whack-a-Mole Game
 
+## Play the Game Online
+You can play the game directly in your browser by visiting:
+[Whack-a-Mole Game Link](https://raw.githack.com/rumple/jules-bus/main/index.html)
+
 A simple browser-based Whack-a-Mole game implemented in a single HTML file using HTML, CSS, and JavaScript.
 
 ## How to Play


### PR DESCRIPTION
I've added a new section "Play the Game Online" to README.md with a direct link to the game hosted on raw.githack.com. This makes it easier for you to quickly access and play the game.